### PR TITLE
Removed the unnecessary call to advance offset in _ConsumeString

### DIFF
--- a/FuzzedDataProviderCSLibrary/FuzzedDataProviderCSLibrary.cs
+++ b/FuzzedDataProviderCSLibrary/FuzzedDataProviderCSLibrary.cs
@@ -438,7 +438,6 @@ namespace FuzzedDataProviderCSLibrary
                 (_data.Length - _offset) + ((_data.Length - _offset) % sizeof(Char) == 0 ? 0 : 1) : 
                 sizeof(Char) * (int)length;
             var toBeConverted = ConsumeBytes(step);            
-            Advance(step);
 
             var strBuilder = IsLittleEndian ? 
                 new StringBuilder(Encoding.BigEndianUnicode.GetString(toBeConverted)) :

--- a/FuzzedDataProviderCSTest/UnitTest1.cs
+++ b/FuzzedDataProviderCSTest/UnitTest1.cs
@@ -613,5 +613,22 @@ namespace FuzzedDataProviderCSTest
                 }
             }
         }
+        
+        [TestMethod]
+        public void TestOverflowConsumeRemaining()
+        {
+            using (Stream s = new MemoryStream(new byte[6] { 0x00, 0x02, 0x41, 0x41, 0x41, 0x41 }))
+            {
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    s.CopyTo(ms);
+                    var fdp = new FuzzedDataProviderCS(ms.ToArray());
+                    var v1_len = fdp.ConsumeUInt16();
+                    var v1 = fdp.ConsumeString(v1_len);
+                    if (fdp.InsufficientData) return;
+                    var v2 = fdp.ConsumeRemainingAsString();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
In `ConsumeString` implementation there is no need to call the `Advance` function, which shifts the value of ` _offset` variable. Because this is already accomplished by `ConsumeBytes(step)` call. Otherwise the index in `_offset` will be incremented two times, which can lead to going over `Length` value.